### PR TITLE
Catchup from mikesugarcrm

### DIFF
--- a/lib/Exceptions.php
+++ b/lib/Exceptions.php
@@ -93,9 +93,9 @@ class ServerError extends \SugarRestHarness\Exception
         '503' => 'Server is in Mainenance mode',
     );
     
-    public function __construct($httpReturnCode, $errors)
+    public function __construct($httpReturnCode, $expectedReturnCode, $errors)
     {
-        $msg = "Server returned a $httpReturnCode error";
+        $msg = "Server returned a $httpReturnCode error, expected a $expectedReturnCode";
         if (IsSet($this->msgMap[$httpReturnCode])) {
             $msg .= " - {$this->msgMap[$httpReturnCode]}";
         }
@@ -222,26 +222,6 @@ class WriteToFileFailed extends \SugarRestHarness\Exception
 }
 
 
-class RandomDataTypeDoesNotExist extends \SugarRestHarness\Exception
-{
-    public function __construct($badType)
-    {
-        $msg = "There is no Randomizer class 'Randomizer$badType'. Please check your randomizer type name.";
-        parent::__construct($msg);
-    }
-}
-
-
-class RandomDataClassIsNotDefined extends \SugarRestHarness\Exception
-{
-    public function __construct($filePath, $className)
-    {
-        $msg = "The randomizer file $filePath does not define the class '$className'.";
-        parent::__construct($msg);
-    }
-}
-
-
 class RandomDataKeyIsInvalid extends \SugarRestHarness\Exception
 {
     public function __construct($badKey, $finalKey)
@@ -282,41 +262,30 @@ class RandomDataAppListStringNotFound extends \SugarRestHarness\Exception
 }
 
 
-class ExpectationClassFileNotFound extends \SugarRestHarness\Exception
-{
-    public function __construct($classFilePath)
-    {
-        $msg = "The file '$classFilePath' does not exist or could not be opened.";
-        parent::__construct($msg);
-    }
-}
-
-
-class ExpectationClassNotDefined extends \SugarRestHarness\Exception
+class ClassFileNotFound extends \SugarRestHarness\Exception
 {
     public function __construct($className, $classFilePath)
     {
-        $msg = "The file '$classFilePath' does not define $className. Please make sure the class is is correct, including the namespace.";
+        if (is_array($classFilePath)) {
+            $classFilePath = implode(",\n", $classFilePath);
+        }
+        
+        $msg = "While trying to instantiate $className, we looked for class files in these locations:\n$classFilePath\n";
+        $msg .= "None of them exist or they are not readable. Please check your class name and files.";
         parent::__construct($msg);
     }
 }
 
 
-class FormatterClassFileNotFound extends \SugarRestHarness\Exception
-{
-    public function __construct($classFilePath)
-    {
-        $msg = "The file '$classFilePath' does not exist or could not be opened.";
-        parent::__construct($msg);
-    }
-}
-
-
-class FormatterClassNotDefined extends \SugarRestHarness\Exception
+class ClassIsNotDefined extends \SugarRestHarness\Exception
 {
     public function __construct($className, $classFilePath)
     {
-        $msg = "The file '$classFilePath' does not define $className. Please make sure the class is is correct, including the namespace.";
+        if (is_array($classFilePath)) {
+            $classFilePath = implode(",\n", $classFilePath);
+        }
+        
+        $msg = "The class $className is not defined in any of these locations:\n$classFilePath.\nPlease make sure the class name is is correct, including the namespace.";
         parent::__construct($msg);
     }
 }

--- a/lib/ExpectationsEngine.php
+++ b/lib/ExpectationsEngine.php
@@ -33,7 +33,6 @@ class ExpectationsEngine
 {
     protected $job;
     protected $exceptions = array();
-    protected $loadedExpectationTesters = array();
     
     
     /**
@@ -61,9 +60,9 @@ class ExpectationsEngine
     /**
      * loadExpectationTesterClass()
      *
-     * Searches for the correct expectation class file and loads it. Throws an
-     * Exception if it can't find the file or if the file doesn't define the
-     * necessary class. Returns an instantiation of the required expectation
+     * Searches for the correct expectation class file and loads it. If the file
+     * cannot be found, or does not define the specified class, the Harness's autoload
+     * method will throw an exception. Returns an instantiation of the required expectation
      * tester class.
      *
      * @param string $className - the name of an expectation class.
@@ -73,22 +72,7 @@ class ExpectationsEngine
     public function loadExpectationTesterClass($className)
     {
         $className = ucfirst($className);
-        $classFilePath = \SugarRestHarness\Harness::getAbsolutePath("lib/Expectations/{$className}.php");
-        
         $namespacedClassName = "\\SugarRestHarness\\Expectations\\$className";
-        
-        if (!in_array($className, $this->loadedExpectationTesters)) {
-            if (!file_exists($classFilePath)) {
-                throw new \SugarRestHarness\ExpectationClassFileNotFound($classFilePath);
-            }
-            
-            if (!class_exists($namespacedClassName)) {
-                throw new \SugarRestHarness\ExpectationClassNotDefined($className, $classFilePath);
-            }
-            // class_exists() will trigger the autoloader to load the correct class file.
-            // if we get this far, our expectation tester is loaded.
-            $this->loadedExpectationTesters[] = $className;
-        }
         
         $tester = new $namespacedClassName();
         return $tester;

--- a/lib/RandomizerFactory.php
+++ b/lib/RandomizerFactory.php
@@ -46,16 +46,13 @@ class RandomizerFactory
     /**
      * Loads the specified type of Randomizer. Randomizer names must match an
      * existing Randomizer class, i.e. RandomizerNumber, which must be defined in
-     * Randomizers/RandomizerNumber.php.
+     * lib/Randomizers/RandomizerNumber.php or custom/lib/Randomizers/RandomizerNumber.php.
      *
-     * This function will require the class file (if it exists), instantiate the
-     * class, cache it in this class's randomizers array, and return the instantiated
-     * class.
+     * This function will cache an instantiaion of the specified class in this 
+     * class's randomizers array, and return the instantiated class.
      *
      * @param string $name - the name of the randomizer you want to load.
      * @return RandomizerAbstact - a randomizer object.
-     * @throws RandomDataTypeDoesNotExist
-     * @throws RandomDataClassIsNotDefined
      */
     public function loadRandomizer($name)
     {
@@ -63,17 +60,6 @@ class RandomizerFactory
         $className = "\SugarRestHarness\Randomizers\Randomizer{$name}";
         
         if (!isset($this->randomizers[$className])) {
-            $path = \SugarRestHarness\Harness::getAbsolutePath("lib/Randomizers/$fileName.php");
-            if (!file_exists($path)) {
-                throw new \SugarRestHarness\RandomDataTypeDoesNotExist($name);
-            }
-            
-            require_once($path);
-            
-            if (!class_exists($className)) {
-                throw new \SugarRestHarness\RandomDataClassIsNotDefined($path, $className);
-            }
-            
             $this->randomizers[$className] = $className::getInstance();
         }
         

--- a/lib/RestConnector.php
+++ b/lib/RestConnector.php
@@ -78,6 +78,7 @@ class RestConnector
     public $prefName = '';
     public $jobClass = '';
     public $filters = array();
+    public $expectedHTTPReturnCode = '200';
     
     public $msgs = array();
     public $errors = array();
@@ -808,8 +809,9 @@ class RestConnector
             $results = curl_exec($ch);
             $this->collecthttpReturn($ch);
             curl_close($ch);
-            if ($this->httpReturn['HTTP Return Code'] != '200') {
-                throw new \SugarRestHarness\ServerError($this->httpReturn['HTTP Return Code'], $results);
+            if ($this->httpReturn['HTTP Return Code'] != $this->expectedHTTPReturnCode 
+                && $this->httpReturn['HTTP Return Code'] != '200') {
+                throw new \SugarRestHarness\ServerError($this->httpReturn['HTTP Return Code'], $this->expectedHTTPReturnCode, $results);
             }
             return $results;
         } else {
@@ -817,7 +819,23 @@ class RestConnector
             $this->report();
             return false;
         }
-        
+    }
+    
+    
+    /**
+     * setExpectedHTTPReturnCode()
+     *
+     * Sets the expected return code. If the request this connector sends returns
+     * an http return code value that is different from what you set here, a
+     * ServerError exception will be thrown in the sendRequest() method.
+     *
+     * The default value is '200'.
+     *
+     * @param string $code - the expected return code, i.e. 200, 404, 500, etc.
+     */
+    public function setExpectedHTTPReturnCode($code)
+    {
+        $this->expectedHTTPReturnCode = $code;
     }
     
     


### PR DESCRIPTION
Updates to autoloading custom files, and for setting expectations programmatically.

Improved the loading of custom classes by removing the various loading 
methods for formatters, expectations and randmoizers. Now, the Harness class's
autoload method will always handle loading those classes, and will check
for custom versions of them before loading the regular version.
Also added generic exceptions for "file not found" and "class not defined"
conditions, and removed the class-specific versions of those exceptions.

Added some code for setting expectations on a job programmatically. This allows JobSeries to
set expectations on Jobs as it works through the series.

Also put in some special handling around setting the expected HTTP return code value.

If an expectation sets the expected value for the http return code, receiving that code
should not trigger an exception. Receiving a different code should. However, a 200 should
never trigger an exception because when it does, we don't see the results of the request.
Those could be very informative and should be displayed.