### PR TITLE
Add capacity on the Config class to store the user's ID and the OAuth…

### DIFF
--- a/lib/Config.php
+++ b/lib/Config.php
@@ -42,6 +42,12 @@ class Config
     /** @var array all options in the job's config array. */
     public $jobConfigParams = array();
     
+    /** @var string the OAuth2 token value */
+    public $token = '';
+    
+    /** @var string the ID of the currently logged in user (NOT the user_name, the id) */
+    public $myId = '';
+    
     
     /**
      * __construct()
@@ -345,6 +351,7 @@ class Config
         $this->importConfigFile($this->getConfigFileName());
         $configParams = $this->merge($this->configFileOptions, $jobConfigHash);
         $configParams = $this->merge($configParams, $this->commandLineOptions);
+        $configParams['token'] = $this->token;
         return $configParams;
     }
     
@@ -430,7 +437,7 @@ class Config
         $this->processArgv();
         $this->importConfigFile($this->getConfigFileName());
         $configParams = array();
-        $configParams = array_merge($this->configFileOptions, $this->commandLineOptions);
+        $configParams = array_merge($this->configFileOptions, $this->commandLineOptions, array('token' => $this->token));
         return $configParams;
     }
     
@@ -451,5 +458,69 @@ class Config
             $configFileName = $this->commandLineOptions['configFileName'];
         }
         return $configFileName;
+    }
+    
+    
+    /**
+     * setToken()
+     *
+     * Sets the OAuth2 token on this object for later retrieval.
+     *
+     * @param string $token - an OAuth2 token.
+     * @param bool $force - optional, default is false. If $force is true, set the
+     *  token to whatever value was passed in $token.
+     * @return string - the token currently set on this object.
+     */
+    public function setToken($token, $force=false)
+    {
+        if (empty($this->token) || $force) {
+            $this->token = $token;
+        }
+        return $this->token;
+    }
+    
+    
+    /**
+     * getToken()
+     *
+     * Returns the current OAuth2 token on this object.
+     *
+     * @return string  - the current OAuth2 token.
+     */
+    public function getToken()
+    {
+        return $this->token;
+    }
+    
+    
+    /**
+     * setMyId()
+     *
+     * Sets the ID of the current user for retrieval by multiple jobs running under
+     * the same user.
+     *
+     * @param string $token - a user id (ID, not user_name).
+     * @param bool $force - optional, default is false. If $force is true, set the
+     *  myId to whatever value was passed in $id.
+     * @return string - the user id currently set on this object.
+     */
+    public function setMyId($id, $force=false) {
+        if (empty($this->myId) || $force) {
+            $this->myId = $id;
+        }
+        return $this->myId;
+    }
+    
+    
+    /**
+     * getMyId()
+     *
+     * Returns the current user id on this object.
+     *
+     * @return string  - the current user id.
+     */
+    public function getMyId()
+    {
+        return $this->myId;
     }
 }

--- a/lib/Formatters/FormatterConcise.php
+++ b/lib/Formatters/FormatterConcise.php
@@ -34,7 +34,7 @@ class FormatterConcise extends \SugarRestHarness\Formatters\FormatterBase implem
         $resultsStrings = array();
         foreach ($results as $result) {
             $parts = array();
-            $success = $result->connector->httpReturn['HTTP Return Code'] == '200' ? 'Success' : 'Failed';
+            $success = $result->connector->receivedExpectedHTTPReturnCode() ? 'Success' : 'Failed';
             $resultsStrings[] = "\n{$result->id} $success";
             foreach ($this->headersAndMethods as $header => $method) {
                 $formattedString = trim($this->$method($result));
@@ -85,7 +85,7 @@ class FormatterConcise extends \SugarRestHarness\Formatters\FormatterBase implem
      */
     public function formatHTTPReturn(\SugarRestHarness\JobAbstract $jobObj)
     {
-        if ($jobObj->connector->httpReturn['HTTP Return Code'] == '200') {
+        if ($jobObj->connector->receivedExpectedHTTPReturnCode()) {
             return "Content-Length: " . $jobObj->connector->httpReturn['Content-Length'];
         } else {
             return parent::formatHTTPReturn($jobObj);

--- a/lib/JobAbstract.php
+++ b/lib/JobAbstract.php
@@ -242,19 +242,26 @@ abstract class JobAbstract implements JobInterface
      */
     public function getMyId()
     {
-        static $results;
+        $myID = \SugarRestHarness\Config::getInstance()->getMyId();
         
-        if (!isset($results)) {
+        if (empty($myID)) {
             $config = array(
                 'method' => 'GET',
                 'route' => '/me'
             );
-        
+            
             $job = new \SugarRestHarness\Jobs\Generic($config);
-            $job->rawResults = $job->connector->makeRequest();
+            
+            try {
+                $job->rawResults = $job->connector->makeRequest();
+            } catch (Exception $e) {
+                $e->output();
+            }
+            
             $results = json_decode($job->rawResults, true);
+            $myID = \SugarRestHarness\Config::getInstance()->setMyId($results['current_user']['id']);
         }
-        return $results['current_user']['id'];
+        return $myID;
     }
     
     


### PR DESCRIPTION
…2 token.

Storing these values in this way reduces the number of outbound calls to the server
to retrieve these values.

Also added some changes around expectation checking for HTTP return codes. Now, if a
job gets its expected return code, that's a successful job even if the return code was
a 404 or something. If it's what we expect, it's a success.