### PR TITLE
Improve the text handling for when the harness checks a "contains" ex…

### DIFF
--- a/lib/Expectations/Contains.php
+++ b/lib/Expectations/Contains.php
@@ -39,6 +39,10 @@ class Contains extends \SugarRestHarness\Expectations\ExpectationsAbstract imple
                 $met = in_array($expected, $actual);
                 $actual = 'an array';
                 break;
+            case 'object':
+                $met = property_exists($actual, $expected);
+                $actual = 'an object';
+                break;
             case 'NULL':
                 $met = is_null($expected);
                 break;


### PR DESCRIPTION
…pectation

and the type of the object being checked is an object, instead of an array